### PR TITLE
Remove some non-determinism

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -2,6 +2,8 @@ project(baresip)
 
 cmake_minimum_required(VERSION 3.4.1)
 
+add_link_options("LINKER:--build-id=none")
+
 set(distribution_DIR ${CMAKE_SOURCE_DIR}/../../../../distribution)
 
 add_library(lib_crypto STATIC IMPORTED)


### PR DESCRIPTION
Your apps are not built reproducible in F-Droid, but we continuously test older versions on https://verification.f-droid.org/ and would like more and more apps to become repro

Looking at the latest apps report: https://verification.f-droid.org/packages/com.tutpro.baresip/ & https://verification.f-droid.org/packages/com.tutpro.baresip.plus/

We can fix the BUILD_ID issue here.

And the "date" issue brought by OpenSSL will be fixed by the recently merged https://gitlab.com/fdroid/fdroidserver/-/merge_requests/1653 as the OpenSSL build (and cmake) respect `SOURCE_DATE_EPOCH`